### PR TITLE
Allow setting options via ENV vars and add offline mode

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -27,7 +27,13 @@
     },
     "runArgs": [
         "-e",
-        "TZ=Europe/Berlin"
+        "TZ=Europe/Berlin",
+        "-e",
+        "PRINTER_MODEL=QL-800",
+        "-e",
+        "PRINTER_PRINTER=file:///dev/usb/lp0",
+        "-e",
+        "PRINTER_OFFLINE=true"
         //        "-v",
         //        "/dev/usb/lp0:/dev/usb/lp0",
         //        "/dev/usb/lp1:/dev/usb/lp1",

--- a/README.md
+++ b/README.md
@@ -120,9 +120,11 @@ services:
       - "8013:8013"
     devices:
       - "/dev/usb/lp0:/dev/usb/lp0"
-    command: >
-      --default-label-size 62
-      file:///dev/usb/lp0
+    environment:
+      - LABEL_DEFAULT_SIZE=62
+      - LABEL_DEFAULT_ORIENTATION=standard
+      - PRINTER_MODEL=QL-800
+      - PRINTER_PRINTER=file:///dev/usb/lp0
 ```
 
 To build the image locally:

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -5,6 +5,7 @@
 This is a web service to print labels on Brother QL label printers.
 """
 
+import os
 import sys
 import random
 import argparse
@@ -72,14 +73,16 @@ def init_fonts_and_args(app):
 def parse_args(app):
     models = [model.identifier for model in ALL_MODELS]
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument('--default-label-size', default=None,
+    parser.add_argument('--default-label-size', default=os.getenv('LABEL_DEFAULT_SIZE', app.config['LABEL_DEFAULT_SIZE']),
                         help='Label size inserted in your printer. Defaults to 62.')
-    parser.add_argument('--default-orientation', default=None, choices=('standard', 'rotated'),
+    parser.add_argument('--default-orientation', default=os.getenv('LABEL_DEFAULT_ORIENTATION', app.config['LABEL_DEFAULT_ORIENTATION']), choices=('standard', 'rotated'),
                         help='Label orientation, defaults to "standard". To turn your text by 90°, state "rotated".')
-    parser.add_argument('--model', default=None, choices=models,
+    parser.add_argument('--model', default=os.getenv('PRINTER_MODEL', app.config['PRINTER_MODEL']), choices=models,
                         help='The model of your printer (default: QL-500)')
-    parser.add_argument('printer', nargs='?', default=None,
+    parser.add_argument('printer', nargs='?', default=os.environ.get('PRINTER_PRINTER', app.config['PRINTER_PRINTER']),
                         help='String descriptor for the printer to use (like tcp://192.168.0.23:9100 or file:///dev/usb/lp0)')
+    parser.add_argument('--offline', action='store_true', default=os.environ.get('PRINTER_OFFLINE', app.config['PRINTER_OFFLINE']),
+                        help='Run the printer in offline mode (default: false)')
     args = parser.parse_args()
 
     if args.printer:
@@ -90,3 +93,5 @@ def parse_args(app):
         app.config['LABEL_DEFAULT_SIZE'] = args.default_label_size
     if args.default_orientation:
         app.config['LABEL_DEFAULT_ORIENTATION'] = args.default_orientation
+    if args.offline:
+        app.config['PRINTER_OFFLINE'] = args.offline

--- a/app/labeldesigner/routes.py
+++ b/app/labeldesigner/routes.py
@@ -1,24 +1,26 @@
-import logging
 import os
-
+import logging
+from typing import Any
 import barcode
-from flask import current_app, json, jsonify, render_template, request, make_response
-
-from brother_ql.labels import ALL_LABELS, FormFactor
-
 from . import bp
+from app import FONTS
+from werkzeug.datastructures import FileStorage
+from .printer import PrinterQueue, get_status
+from brother_ql.labels import ALL_LABELS, FormFactor
+from .label import SimpleLabel, LabelContent, LabelOrientation, LabelType
+from flask import Request, current_app, json, jsonify, render_template, request, make_response
 from app.utils import (
     convert_image_to_bw, convert_image_to_grayscale, convert_image_to_red_and_black,
     pdffile_to_image, imgfile_to_image, image_to_png_bytes
 )
-from app import FONTS
-
-from .label import SimpleLabel, LabelContent, LabelOrientation, LabelType
-from .printer import PrinterQueue, get_ptr_status
 
 LINE_SPACINGS = (100, 150, 200, 250, 300)
 DEFAULT_DPI = 300
 HIGH_RES_DPI = 600
+
+@bp.errorhandler(ValueError)
+def handle_value_error(e):
+    return jsonify({"error": str(e)}), 400
 
 @bp.route('/')
 def index():
@@ -90,7 +92,7 @@ def preview_from_image():
 
 @bp.route('/api/printer_status', methods=['GET'])
 def get_printer_status():
-    return get_ptr_status(current_app.config['PRINTER_PRINTER'])
+    return get_status(current_app.config)
 
 
 @bp.route('/api/print', methods=['POST', 'GET'])
@@ -135,7 +137,7 @@ def print_label():
     return return_dict
 
 
-def create_printer_from_request(request):
+def create_printer_from_request(request: Request):
     label_size = request.values.get('label_size', '62')
     return PrinterQueue(
         model=current_app.config['PRINTER_MODEL'],
@@ -144,14 +146,14 @@ def create_printer_from_request(request):
     )
 
 
-def parse_text_form(input):
+def parse_text_form(input: str) -> Any:
     """Parse text form data from frontend."""
     if not input:
         return []
     return json.loads(input)
 
 
-def create_label_from_request(request, counter: int = 0):
+def create_label_from_request(request: Request, counter: int = 0):
     d = request.values
     label_size = d.get('label_size', "62")
     kind = next((label.form_factor for label in ALL_LABELS if label.identifier == label_size), None)
@@ -183,7 +185,7 @@ def create_label_from_request(request, counter: int = 0):
         'high_res': int(d.get('high_res', 0)) != 0
     }
 
-    def get_label_dimensions(label_size, high_res: bool = False):
+    def get_label_dimensions(label_size: str, high_res: bool = False):
         dimensions = next((label.dots_printable for label in ALL_LABELS if label.identifier == label_size), None)
         if dimensions is None:
             raise LookupError("Unknown label_size")
@@ -200,7 +202,7 @@ def create_label_from_request(request, counter: int = 0):
             raise LookupError(f"Unknown font style: {style_name} for font {family_name}")
         return FONTS.fonts[family_name][style_name]
 
-    def get_uploaded_image(image):
+    def get_uploaded_image(image: FileStorage):
         name, ext = os.path.splitext(image.filename)
         ext = ext.lower()
         if ext in ('.png', '.jpg', '.jpeg'):

--- a/app/labeldesigner/routes.py
+++ b/app/labeldesigner/routes.py
@@ -5,7 +5,7 @@ import barcode
 from . import bp
 from app import FONTS
 from werkzeug.datastructures import FileStorage
-from .printer import PrinterQueue, get_status
+from .printer import PrinterQueue, get_ptr_status
 from brother_ql.labels import ALL_LABELS, FormFactor
 from .label import SimpleLabel, LabelContent, LabelOrientation, LabelType
 from flask import Request, current_app, json, jsonify, render_template, request, make_response
@@ -92,7 +92,7 @@ def preview_from_image():
 
 @bp.route('/api/printer_status', methods=['GET'])
 def get_printer_status():
-    return get_status(current_app.config)
+    return get_ptr_status(current_app.config)
 
 
 @bp.route('/api/print', methods=['POST', 'GET'])
@@ -127,7 +127,7 @@ def print_label():
             # - we cut only once and this is the last label to be generated
             cut = not cut_once or (cut_once and i == print_count - 1)
             printer.add_label_to_queue(label, cut, high_res)
-        status = printer.process_queue()
+        status = printer.process_queue(current_app.config['PRINTER_OFFLINE'])
     except Exception as e:
         return_dict['message'] = str(e)
         current_app.logger.exception(e)

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -218,6 +218,21 @@ function gen_label(preview = true, cut_once = false) {
     // Check label against installed label in the printer
     updatePrinterStatus();
 
+    // Update font settings for each line
+    setFontSettingsPerLine();
+
+    // Return early if any of the font styles are empty
+    if (!fontSettingsPerLine || Object.keys(fontSettingsPerLine).length === 0) {
+        console.warn("No font settings available");
+        setStatus({ 'printing': false });
+        return;
+    }
+    if (fontSettingsPerLine.some(line => !line.style)) {
+        console.warn("Some font styles are missing");
+        setStatus({ 'printing': false });
+        return;
+    }
+
     if (preview) {
         // Update preview image based on label size
         if ($('#labelSize option:selected').data('round') == 'True') {
@@ -242,9 +257,6 @@ function gen_label(preview = true, cut_once = false) {
     } else {
         $('#groupLabelImage').hide();
     }
-
-    // Update font settings for each line
-    setFontSettingsPerLine();
 
     // Update status box
     setStatus(preview ? { 'preview': false } : { 'printing': false });
@@ -407,6 +419,7 @@ document.addEventListener('DOMContentLoaded', function () {
 });
 
 function updatePrinterStatus() {
+    const printerIcon = document.getElementById('printerIcon');
     const printerModel = document.getElementById('printerModel');
     if (printerModel) {
         printerModel.textContent = printer_status.model || 'Unknown';
@@ -420,6 +433,16 @@ function updatePrinterStatus() {
     } else {
         $('#print_color_black').prop('active', true);
         $(".red-support").hide();
+    }
+
+    if (printer_status.status_type === 'Offline') {
+        printerModel.classList.add('text-muted');
+        printerPath.classList.add('text-muted');
+        printerIcon.classList.add('text-muted');
+    } else {
+        printerModel.classList.remove('text-muted');
+        printerPath.classList.remove('text-muted');
+        printerIcon.classList.remove('text-muted');
     }
 
     const labelSizeX = document.getElementById('label-width');

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -179,7 +179,6 @@ function get_dpi() {
 }
 
 function updatePreview(data) {
-    setStatus({ 'preview': true });
     $('#previewImg').attr('src', 'data:image/png;base64,' + data);
     var img = $('#previewImg')[0];
     img.onload = function () {
@@ -224,12 +223,12 @@ function gen_label(preview = true, cut_once = false) {
     // Return early if any of the font styles are empty
     if (!fontSettingsPerLine || Object.keys(fontSettingsPerLine).length === 0) {
         console.warn("No font settings available");
-        setStatus({ 'printing': false });
+        setStatus({ type: 'status', status: 'error', message: 'No font settings available' });
         return;
     }
     if (fontSettingsPerLine.some(line => !line.style)) {
         console.warn("Some font styles are missing");
-        setStatus({ 'printing': false });
+        setStatus({ type: 'status', status: 'error', message: 'Some font styles are missing' });
         return;
     }
 
@@ -259,11 +258,12 @@ function gen_label(preview = true, cut_once = false) {
     }
 
     // Update status box
-    setStatus(preview ? { 'preview': false } : { 'printing': false });
+    let type = preview ? 'preview' : 'printing';
+    setStatus({ type: type, 'status': 'pending' });
 
     // Process image upload
     if ($('input[name=printType]:checked').val() == 'image') {
-        dropZoneMode = preview ? 'preview' : 'print';
+        dropZoneMode = preview ? 'preview' : 'printing';
         imageDropZone.processQueue();
         return;
     }
@@ -276,13 +276,19 @@ function gen_label(preview = true, cut_once = false) {
         contentType: 'application/x-www-form-urlencoded; charset=UTF-8',
         data: formData(cut_once),
         success: function (data) {
+            // Check if response is JSON and has a key "success"
+            const status = typeof data === "object" &&
+                data !== null &&
+                "success" in data &&
+                data.success === false ?
+                'error' : 'success';
+            setStatus({ type: type, 'status': status });
             updatePreview(data);
         },
         error: function (xhr, _status, error) {
             message = xhr.responseJSON ? xhr.responseJSON.message : error;
-            data = { 'success': false, 'message': message };
             const text = preview ? 'Preview generation failed' : 'Printing failed';
-            setStatus(data, text);
+            setStatus({ type: type, 'status': 'error', 'message': message }, text);
         }
     });
 }
@@ -296,35 +302,88 @@ function preview() {
 }
 
 function setStatus(data, what = null) {
-    if (data.hasOwnProperty('preview') || data.hasOwnProperty('printing')) {
-        if (data['preview']) {
-            $('#statusPanel').html('<div id="statusBox" class="alert alert-info" role="alert"><i class="fas fa-eye"></i><span>Preview generated successfully.</span></div>');
-            // Status icon green checkmark
-            $('#statusIcon').removeClass().addClass('float-right fas fa-check text-success');
-        }
-        else if (what !== null) {
-            // We are currently busy preparing the preview / printing
-            const what = data.hasOwnProperty('printing') ? "Printing" : "Generating preview";
-            $('#statusPanel').html('<div id="statusBox" class="alert alert-info" role="alert"><i class="fas fa-hourglass-half"></i><span>' + what + '...</span></div>');
-            // Status icon muted hourglass
-            $('#statusIcon').removeClass().addClass('float-right fas fa-hourglass-half text-muted');
-        }
+    let type = data.type || '';
+    let status = data.status || '';
+    let message = data.message || '';
+    let errors = data?.errors || [];
+    console.log(data);
+    let extra_info = message ? ':<br />' + message : '';
+    if (errors.length > 0) {
+        extra_info += '<br />' + errors.join('<br />');
     }
-    else if (data['success']) {
-        $('#statusPanel').html('<div id="statusBox" class="alert alert-success" role="alert"><i class="fas fa-check"></i><span>Printing was successful.</span></div>');
-        // Status icon green printer
-        $('#statusIcon').removeClass().addClass('float-right fas fa-print text-success');
+    console.log(errors);
+
+    // Default: clear status
+    let html = '';
+    let iconClass = '';
+
+    if (type === 'preview' || type === 'printing') {
+        if (status === 'pending') {
+            // Busy preparing preview or printing
+            let action = type === 'printing' ? "Printing" : "Generating preview";
+            html = `<div id="statusBox" class="alert alert-info" role="alert">
+                        <i class="fas fa-hourglass-half"></i>
+                        <span>${action}...</span>
+                    </div>`;
+            iconClass = 'float-right fas fa-hourglass-half text-muted';
+        } else if (status === 'success') {
+            // Success for preview or printing
+            if (type === 'preview') {
+                html = `<div id="statusBox" class="alert alert-info" role="alert">
+                            <i class="fas fa-eye"></i>
+                            <span>Preview generated successfully.</span>
+                        </div>`;
+                iconClass = 'float-right fas fa-check text-success';
+            } else {
+                html = `<div id="statusBox" class="alert alert-success" role="alert">
+                            <i class="fas fa-check"></i>
+                            <span>Printing was successful.</span>
+                        </div>`;
+                iconClass = 'float-right fas fa-print text-success';
+            }
+        } else if (status === 'error') {
+            // Error for preview or printing
+            let action = type === 'preview' ? "Preview generation failed" : "Printing failed";
+            html = `<div id="statusBox" class="alert alert-warning" role="alert">
+                        <i class="fas fa-exclamation-triangle"></i>
+                        <span>${action}${extra_info}</span>
+                    </div>`;
+            iconClass = 'float-right fas fa-exclamation-triangle text-danger';
+        } else {
+            // Unknown status, clear
+            html = "";
+            iconClass = "";
+        }
+    } else if (type === 'status') {
+        if (status === 'error') {
+            let action = "Error";
+            html = `<div id="statusBox" class="alert alert-warning" role="alert">
+                        <i class="fas fa-exclamation-triangle"></i>
+                        <span>${action}${extra_info}</span>
+                    </div>`;
+            iconClass = 'float-right fas fa-exclamation-triangle text-danger';
+        } else {
+            html = "";
+            iconClass = "";
+        }
     } else {
-        extra_info = ''
-        if ('message' in data) {
-            extra_info = ':<br />' + data['message']
-        }
-        if (what !== null) {
-            $('#statusPanel').html('<div id="statusBox" class="alert alert-warning" role="alert"><i class="fas fa-exclamation-triangle"></i><span>' + what + extra_info + '</span></div>');
-        }
-        // Status icon red exclamation
-        $('#statusIcon').removeClass().addClass('float-right fas fa-exclamation-triangle text-danger');
+        html = "";
+        iconClass = "";
     }
+
+    let elem = null;
+    if (type === 'status') {
+        elem = $('#printerStatusPanel');
+    } else {
+        elem = $('#statusPanel');
+    }
+    elem.html(html);
+    if (html.length > 0)
+        elem.show();
+    else
+        elem.hide();
+
+    $('#statusIcon').removeClass().addClass(iconClass);
     $('#printButton').prop('disabled', false);
     $('#dropdownPrintButton').prop('disabled', false);
 }
@@ -364,10 +423,15 @@ Dropzone.options.myAwesomeDropzone = {
 
     success: function (file, response) {
         // If preview or print was successfull update the previewpane or print status
+        // Check if response is JSON and has a key "success"
+        const status = typeof response === "object" &&
+            response !== null &&
+            "success" in response &&
+            response.success === false ?
+            'error' : 'success';
+        setStatus({ type: dropZoneMode, status: status });
         if (dropZoneMode == 'preview') {
             updatePreview(response);
-        } else {
-            setStatus(response);
         }
         file.status = Dropzone.QUEUED;
     },
@@ -439,6 +503,8 @@ function updatePrinterStatus() {
         printerModel.classList.add('text-muted');
         printerPath.classList.add('text-muted');
         printerIcon.classList.add('text-muted');
+        // Append " (offline)" to printer path
+        printerPath.textContent += " (offline)";
     } else {
         printerModel.classList.remove('text-muted');
         printerPath.classList.remove('text-muted');
@@ -476,25 +542,11 @@ function updatePrinterStatus() {
     }
 
     if (printer_status.errors && printer_status.errors.length > 0) {
-        setStatus({ 'success': false })
-        const printerErrors = document.getElementById('printerStatusBox');
-        if (printerErrors) {
-            printerErrors.innerHTML = '';
-            printer_status.errors.forEach((error) => {
-                const li = document.createElement('li');
-                li.textContent = error;
-                printerErrors.appendChild(li);
-            });
-            printerErrors.parentElement.style.display = '';
-        }
+        setStatus({ type: 'status', status: 'error', errors: printer_status.errors });
     }
     else {
         // Clear printer errors
-        const printerErrors = document.getElementById('printerStatusBox');
-        if (printerErrors) {
-            printerErrors.innerHTML = '';
-            printerErrors.parentElement.style.display = 'none';
-        }
+        setStatus({ type: 'status', status: 'success' });
     }
 }
 

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -48,7 +48,7 @@ Label Designer | Brother QL
             <ul class="navbar-nav ml-auto">
                 <li class="nav-item d-flex align-items-center">
                     <span class="nav-link pr-2" style="display: flex; align-items: center; gap: 0.5em;">
-                        <span class="fas fa-print" aria-hidden="true"></span>
+                        <span class="fa-solid fa-print" aria-hidden="true" id="printerIcon"></span>
                         <span id="printerInfo" style="color: #fff; font-size: 1em;">
                             <span id="printerModel">???</span>
                             <span style="color: #aaa;">@</span>

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -48,7 +48,7 @@ Label Designer | Brother QL
             <ul class="navbar-nav ml-auto">
                 <li class="nav-item d-flex align-items-center">
                     <span class="nav-link pr-2" style="display: flex; align-items: center; gap: 0.5em;">
-                        <span class="fa-solid fa-print" aria-hidden="true" id="printerIcon"></span>
+                        <span class="fas fa-print" aria-hidden="true" id="printerIcon"></span>
                         <span id="printerInfo" style="color: #fff; font-size: 1em;">
                             <span id="printerModel">???</span>
                             <span style="color: #aaa;">@</span>

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,42 +1,48 @@
 # -*- coding: utf-8 -*-
 
 from PIL import Image
-from PIL.ImageOps import colorize
 from io import BytesIO
+from PIL.ImageOps import colorize
 from pdf2image import convert_from_bytes
+from werkzeug.datastructures import FileStorage
 
 
-def convert_image_to_bw(image, threshold):
-    fn = lambda x : 255 if x > threshold else 0
-    return image.convert('L').point(fn, mode='1') # convert to black and white
-
-def convert_image_to_grayscale(image):
-    fn = lambda x : 255 if x > threshold else 0
-    return image.convert('L') # convert to greyscale
-
-def convert_image_to_red_and_black(image):
-    return colorize(image.convert('L'), black='black', white='white', mid='red')
+def convert_image_to_bw(image: Image.Image, threshold: int) -> Image.Image:
+    def apply_threshold(pixel: int) -> int:
+        return 255 if pixel > threshold else 0
+    # convert to black and white
+    return image.convert('L').point(apply_threshold, mode='1')
 
 
-def imgfile_to_image(file):
+def convert_image_to_grayscale(image: Image.Image) -> Image.Image:
+    # convert to grayscale (ITU-R 601-2 Luma transform)
+    return image.convert('L')
+
+
+def convert_image_to_red_and_black(image: Image.Image,
+                                   blackpoint: int = 0,
+                                   whitepoint: int = 255,
+                                   redpoint: int = 127) -> Image.Image:
+    return colorize(image.convert('L'), black='black', white='white', mid='red',
+                    blackpoint=blackpoint, whitepoint=whitepoint, midpoint=redpoint)
+
+
+def imgfile_to_image(file: FileStorage) -> Image.Image:
     s = BytesIO()
     file.save(s)
     im = Image.open(s)
     return im
 
 
-def pdffile_to_image(file, dpi):
+def pdffile_to_image(file: FileStorage, dpi: int) -> Image.Image:
     s = BytesIO()
     file.save(s)
     s.seek(0)
-    im = convert_from_bytes(
-        s.read(),
-        dpi = dpi
-    )[0]
+    im = convert_from_bytes(s.read(), dpi=dpi)[0]
     return im
 
 
-def image_to_png_bytes(im):
+def image_to_png_bytes(im: Image.Image) -> bytes:
     image_buffer = BytesIO()
     im.save(image_buffer, format="PNG")
     image_buffer.seek(0)

--- a/config.py
+++ b/config.py
@@ -15,6 +15,7 @@ class Config(object):
     SERVER_PORT = 8013
     SERVER_HOST = '0.0.0.0'
 
+    PRINTER_OFFLINE = False
     PRINTER_MODEL = 'QL-500'
     PRINTER_PRINTER = 'file:///dev/usb/lp1'
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,11 +8,15 @@ services:
       - "8013:8013"
     environment:
       - TZ=Europe/Berlin
+      - LABEL_DEFAULT_SIZE=62
+      - LABEL_DEFAULT_ORIENTATION=standard
+      - PRINTER_MODEL=QL-800
+      - PRINTER_PRINTER=file:///dev/usb/lp0
 #    devices:
 #      - "/dev/usb/lp0:/dev/usb/lp0"
     volumes:
       - /etc/timezone:/etc/timezone:ro
-    command: >
-      --model QL-800
-      --default-label-size 62
-      file:///dev/usb/lp0
+#    command: >
+#      --model QL-800
+#      --default-label-size 62
+#      file:///dev/usb/lp0

--- a/tests/test_labeldesigner_api.py
+++ b/tests/test_labeldesigner_api.py
@@ -103,13 +103,13 @@ class TestLabelDesignerAPI:
     def image_updating_is_disabled(self):
         assert not UPDATE_IMAGES
 
-    def test_render_frontend(self, client):
+    def test_render_frontend(self, client: FlaskClient):
         response = client.get('/labeldesigner/')
         assert response.status_code == 200
         assert b'labeldesigner' in response.data
         assert response.content_type == 'text/html; charset=utf-8'
 
-    def test_get_styles(self, client):
+    def test_get_styles(self, client: FlaskClient):
         response = client.get('/labeldesigner/api/font/styles')
         assert response.status_code == 200
         assert response.is_json
@@ -119,7 +119,7 @@ class TestLabelDesignerAPI:
         assert 'Italic' in data
         assert 'Book' in data
 
-    def test_get_barcodes(self, client):
+    def test_get_barcodes(self, client: FlaskClient):
         response = client.get('/labeldesigner/api/barcodes')
         assert response.status_code == 200
         assert response.is_json
@@ -128,7 +128,7 @@ class TestLabelDesignerAPI:
         assert 'QR' in offered_barcodes
         assert 'EAN13' in offered_barcodes
 
-    def test_generate_preview(self, client):
+    def test_generate_preview(self, client: FlaskClient):
         data = EXAMPLE_FORMDATA.copy()
         data['text'] = json.dumps([
             {
@@ -154,7 +154,7 @@ class TestLabelDesignerAPI:
         # Check image
         self.verify_image(response.data, 'simple.png')
 
-    def test_generate_preview_high_res(self, client):
+    def test_generate_preview_high_res(self, client: FlaskClient):
         data = EXAMPLE_FORMDATA.copy()
         data['high_res'] = 1
         data['text'] = json.dumps([
@@ -181,7 +181,7 @@ class TestLabelDesignerAPI:
         # Check image
         self.verify_image(response.data, 'simple_high_res.png')
 
-    def test_generate_preview_inverted(self, client):
+    def test_generate_preview_inverted(self, client: FlaskClient):
         data = EXAMPLE_FORMDATA.copy()
         data['text'] = json.dumps([
             {
@@ -224,7 +224,7 @@ class TestLabelDesignerAPI:
         # Check image
         self.verify_image(response.data, 'inverted_text.png')
 
-    def test_generate_preview_rotated(self, client):
+    def test_generate_preview_rotated(self, client: FlaskClient):
         data = EXAMPLE_FORMDATA.copy()
         data['orientation'] = 'rotated'
         data['text'] = json.dumps([
@@ -250,7 +250,7 @@ class TestLabelDesignerAPI:
         # Check image
         self.verify_image(response.data, 'rotated.png')
 
-    def test_generate_ean13(self, client):
+    def test_generate_ean13(self, client: FlaskClient):
         data = EXAMPLE_FORMDATA.copy()
         data['print_type'] = 'qrcode_text'
         data['barcode_type'] = 'ean13'
@@ -277,7 +277,7 @@ class TestLabelDesignerAPI:
         # Check image
         self.verify_image(response.data, 'barcode_ean13.png')
 
-    def test_invalid_ean13(self, client):
+    def test_invalid_ean13(self, client: FlaskClient):
         data = EXAMPLE_FORMDATA.copy()
         data['print_type'] = 'qrcode_text'
         data['barcode_type'] = 'ean13'
@@ -303,7 +303,7 @@ class TestLabelDesignerAPI:
         data = response.get_json()
         assert data['message'] == 'EAN must have 12 digits, received 10.'
 
-    def test_generate_qr(self, client):
+    def test_generate_qr(self, client: FlaskClient):
         data = EXAMPLE_FORMDATA.copy()
         data['print_type'] = 'qrcode_text'
         data['barcode_type'] = 'QR'
@@ -330,46 +330,46 @@ class TestLabelDesignerAPI:
         # Check image
         self.verify_image(response.data, 'qr.png')
 
-    def test_image(self, client):
+    def test_image(self, client: FlaskClient):
         self.run_image_test(client)
 
-    def test_image_fit(self, client):
+    def test_image_fit(self, client: FlaskClient):
         self.run_image_test(client, fit=True)
 
-    def test_image_rotated(self, client):
+    def test_image_rotated(self, client: FlaskClient):
         self.run_image_test(client, rotated=True)
 
-    def test_image_rotated_fit(self, client):
+    def test_image_rotated_fit(self, client: FlaskClient):
         self.run_image_test(client, rotated=True, fit=True)
 
-    def test_image_with_text(self, client):
+    def test_image_with_text(self, client: FlaskClient):
         self.run_image_test(client, text=True)
 
-    def test_image_with_text_fit(self, client):
+    def test_image_with_text_fit(self, client: FlaskClient):
         self.run_image_test(client, text=True, fit=True)
 
-    def test_image_with_text_rotated(self, client):
+    def test_image_with_text_rotated(self, client: FlaskClient):
         self.run_image_test(client, text=True, rotated=True)
 
-    def test_image_with_text_fit_rotated(self, client):
+    def test_image_with_text_fit_rotated(self, client: FlaskClient):
         self.run_image_test(client, text=True, rotated=True, fit=True)
 
-    def test_image_color_fit(self, client):
+    def test_image_color_fit(self, client: FlaskClient):
         self.run_image_test(client, image_mode="colored", fit=True)
 
-    def test_image_red_and_black_fit(self, client):
+    def test_image_red_and_black_fit(self, client: FlaskClient):
         self.run_image_test(client, image_mode="red_and_black", fit=True)
 
-    def test_image_black_fit(self, client):
+    def test_image_black_fit(self, client: FlaskClient):
         self.run_image_test(client, image_mode="black", fit=True)
 
-    def test_image_highres(self, client):
+    def test_image_highres(self, client: FlaskClient):
         self.run_image_test(client, high_res=True)
 
-    def test_image_highres_fit(self, client):
+    def test_image_highres_fit(self, client: FlaskClient):
         self.run_image_test(client, high_res=True, fit=True)
 
-    def test_generate_template(self, client):
+    def test_generate_template(self, client: FlaskClient):
         data = EXAMPLE_FORMDATA.copy()
         # Mock current datetime.now
         data['timestamp'] = int(datetime(2023, 3, 18, 12, 15, 30).timestamp())
@@ -416,7 +416,7 @@ class TestLabelDesignerAPI:
         # Check image
         self.verify_image(response.data, 'template.png')
 
-    def test_invalid_data_types(self, client):
+    def test_invalid_data_types(self, client: FlaskClient):
         # Non-integer label_size
         data = EXAMPLE_FORMDATA.copy()
         data['label_size'] = 'sixty-two'
@@ -434,7 +434,7 @@ class TestLabelDesignerAPI:
         assert response.is_json
         assert 'message' in response.get_json()
 
-    def test_large_input_handling(self, client):
+    def test_large_input_handling(self, client: FlaskClient):
         # Very large text
         data = EXAMPLE_FORMDATA.copy()
         data['text'] = json.dumps([
@@ -444,7 +444,7 @@ class TestLabelDesignerAPI:
         # 413 = Content Too Large
         assert response.status_code == 413
 
-    def test_unsupported_barcode_type(self, client):
+    def test_unsupported_barcode_type(self, client: FlaskClient):
         data = EXAMPLE_FORMDATA.copy()
         data['print_type'] = 'qrcode_text'
         data['barcode_type'] = 'UNSUPPORTED'
@@ -456,7 +456,7 @@ class TestLabelDesignerAPI:
         assert response.is_json
         assert 'message' in response.get_json()
 
-    def test_font_not_found(self, client):
+    def test_font_not_found(self, client: FlaskClient):
         data = EXAMPLE_FORMDATA.copy()
         data['text'] = json.dumps([
             {'family': 'NonExistentFont', 'style': 'Book', 'text': 'Test', 'size': '12', 'align': 'center'}
@@ -466,13 +466,13 @@ class TestLabelDesignerAPI:
         assert response.is_json
         assert 'message' in response.get_json()
 
-    def test_method_enforcement(self, client):
+    def test_method_enforcement(self, client: FlaskClient):
         # POST required for preview
         response = client.get('/labeldesigner/api/preview')
         # 405 = Method Not Allowed
         assert response.status_code == 405
 
-    def test_template_edge_cases(self, client):
+    def test_template_edge_cases(self, client: FlaskClient):
         # Incomplete template
         data = EXAMPLE_FORMDATA.copy()
         data['text'] = json.dumps([
@@ -496,7 +496,7 @@ class TestLabelDesignerAPI:
         # Check image
         self.verify_image(response.data, 'template_unknown.png')
 
-    def test_concurrent_preview_requests(self, client):
+    def test_concurrent_preview_requests(self, client: FlaskClient):
         data = EXAMPLE_FORMDATA.copy()
         results = []
         def make_request(i: int):
@@ -512,7 +512,7 @@ class TestLabelDesignerAPI:
             t.join()
         assert all(code == 200 for code in results)
 
-    def test_invalid_image_upload(self, client):
+    def test_invalid_image_upload(self, client: FlaskClient):
         data = EXAMPLE_FORMDATA.copy()
         fake_file = FileStorage(
             stream=io.BytesIO(b'not an image'),
@@ -529,7 +529,7 @@ class TestLabelDesignerAPI:
         assert 'message' in data
         assert data['message'] == 'Unsupported file type'
 
-    def test_corrupted_image_upload(self, client):
+    def test_corrupted_image_upload(self, client: FlaskClient):
         data = EXAMPLE_FORMDATA.copy()
         corrupted = FileStorage(
             stream=io.BytesIO(b'\x89PNG\r\n\x1a\nBADBADBAD'),
@@ -546,7 +546,7 @@ class TestLabelDesignerAPI:
         assert 'message' in data
         assert data['message'] == 'Truncated File Read'
 
-    def test_empty_label(self, client):
+    def test_empty_label(self, client: FlaskClient):
         data = EXAMPLE_FORMDATA.copy()
         data['text'] = json.dumps([])
         response = client.post('/labeldesigner/api/preview', data=data)
@@ -556,7 +556,7 @@ class TestLabelDesignerAPI:
         # Check image
         self.verify_image(response.data, 'empty_label.png')
 
-    def test_minimal_label(self, client):
+    def test_minimal_label(self, client: FlaskClient):
         # Minimum label_size
         data = EXAMPLE_FORMDATA.copy()
         data['text'] = json.dumps([
@@ -569,7 +569,7 @@ class TestLabelDesignerAPI:
         # Check image
         self.verify_image(response.data, 'minimal_label.png')
 
-    def test_unicode_and_special_characters(self, client):
+    def test_unicode_and_special_characters(self, client: FlaskClient):
         data = EXAMPLE_FORMDATA.copy()
         data['text'] = json.dumps([
             {'family': 'DejaVu Sans', 'style': 'Book', 'text': 'Emoji: 😃', 'size': '32', 'align': 'center'},
@@ -582,7 +582,7 @@ class TestLabelDesignerAPI:
         # Check image
         self.verify_image(response.data, 'unicode.png')
 
-    def test_security_xss(self, client):
+    def test_security_xss(self, client: FlaskClient):
         data = EXAMPLE_FORMDATA.copy()
         data['text'] = json.dumps([
             {'family': 'DejaVu Sans', 'style': 'Book', 'text': '<script>alert(1)</script>', 'size': '32', 'align': 'center'}
@@ -597,12 +597,12 @@ class TestLabelDesignerAPI:
 
 
     @pytest.mark.parametrize('method', ['put', 'delete', 'patch'])
-    def test_invalid_http_methods(self, client, method):
+    def test_invalid_http_methods(self, client: FlaskClient, method):
         func = getattr(client, method)
         response = func('/labeldesigner/api/preview')
         assert response.status_code == 405
 
-    def test_print_red_text(self, client):
+    def test_print_red_text(self, client: FlaskClient):
         data = EXAMPLE_FORMDATA.copy()
         data['text'] = json.dumps([
             {'family': 'DejaVu Sans', 'style': 'Book', 'text': 'Red Text', 'size': '24', 'align': 'center', 'color': 'red'},
@@ -615,7 +615,7 @@ class TestLabelDesignerAPI:
         # Check image
         self.verify_image(response.data, 'red_text.png')
 
-    def test_large_number_of_text_blocks(self, client):
+    def test_large_number_of_text_blocks(self, client: FlaskClient):
         data = EXAMPLE_FORMDATA.copy()
         ALIGNS = ['center', 'left', 'right']
         data['text'] = json.dumps([
@@ -635,7 +635,7 @@ class TestLabelDesignerAPI:
         # Check image
         self.verify_image(response.data, 'large_label.png')
 
-    def test_file_size_limits(self, client):
+    def test_file_size_limits(self, client: FlaskClient):
         # Just below the limit
         data = EXAMPLE_FORMDATA.copy()
         big_content = b'\xff' * (16 * 1024 * 1024 - 100)
@@ -651,7 +651,7 @@ class TestLabelDesignerAPI:
         # File size limit exceeded
         assert response.status_code == 413
 
-    def test_extra_fields_ignored(self, client):
+    def test_extra_fields_ignored(self, client: FlaskClient):
         data = EXAMPLE_FORMDATA.copy()
         data['text'] = json.dumps([
             {'family': 'DejaVu Sans', 'style': 'Book', 'text': 'Extra', 'size': '12', 'align': 'center'}
@@ -664,7 +664,7 @@ class TestLabelDesignerAPI:
         # Check image
         self.verify_image(response.data, 'extra_fields.png')
 
-    def test_multiple_images_failure(self, client):
+    def test_multiple_images_failure(self, client: FlaskClient):
         data = EXAMPLE_FORMDATA.copy()
         file1 = FileStorage(stream=io.BytesIO(b'img1'), filename='img1.jpg', content_type='image/jpeg')
         file2 = FileStorage(stream=io.BytesIO(b'img2'), filename='img2.jpg', content_type='image/jpeg')
@@ -674,7 +674,7 @@ class TestLabelDesignerAPI:
         response = client.post('/labeldesigner/api/preview', data=data)
         assert response.status_code == 400
 
-    def test_image_mode_edge_case(self, client):
+    def test_image_mode_edge_case(self, client: FlaskClient):
         data = EXAMPLE_FORMDATA.copy()
         data['print_type'] = 'image'
         data['image'] = FileStorage(stream=io.BytesIO(b'img'), filename='img.jpg', content_type='image/jpeg')
@@ -682,7 +682,7 @@ class TestLabelDesignerAPI:
         response = client.post('/labeldesigner/api/preview', data=data)
         assert response.status_code == 400
 
-    def test_non_existing_label_size(self, client):
+    def test_non_existing_label_size(self, client: FlaskClient):
         data = EXAMPLE_FORMDATA.copy()
         data['label_size'] = 62.5
         data['text'] = json.dumps([
@@ -691,7 +691,7 @@ class TestLabelDesignerAPI:
         response = client.post('/labeldesigner/api/preview', data=data)
         assert response.status_code == 400
 
-    def test_non_utf8_encoded_text(self, client):
+    def test_non_utf8_encoded_text(self, client: FlaskClient):
         data = EXAMPLE_FORMDATA.copy()
         # Latin-1 encoded string
         text = 'Café'.encode('latin-1')
@@ -699,7 +699,7 @@ class TestLabelDesignerAPI:
         response = client.post('/labeldesigner/api/preview', data=data)
         assert response.status_code == 400
 
-    def test_html_in_text(self, client):
+    def test_html_in_text(self, client: FlaskClient):
         data = EXAMPLE_FORMDATA.copy()
         data['text'] = json.dumps([
             {'family': 'DejaVu Sans', 'style': 'Book', 'text': '<b>Bold</b>', 'size': '12', 'align': 'center'}
@@ -711,7 +711,7 @@ class TestLabelDesignerAPI:
         # Check image
         self.verify_image(response.data, 'html_in_text_plain.png')
 
-    def test_missing_optional_fields(self, client):
+    def test_missing_optional_fields(self, client: FlaskClient):
         data = {
             'print_type': 'text',
             'label_size': 62,
@@ -729,7 +729,7 @@ class TestLabelDesignerAPI:
         # Check image
         self.verify_image(response.data, 'missing_optional_fields.png')
 
-    def test_invalid_json_structure(self, client):
+    def test_invalid_json_structure(self, client: FlaskClient):
         data = EXAMPLE_FORMDATA.copy()
         # JSON string, but not a list
         data['text'] = json.dumps({'foo': 'bar'})
@@ -737,7 +737,7 @@ class TestLabelDesignerAPI:
         assert response.status_code == 400
 
     @pytest.mark.parametrize('size', [0, -1, -100])
-    def test_negative_zero_size(self, client, size):
+    def test_negative_zero_size(self, client: FlaskClient, size):
         data = EXAMPLE_FORMDATA.copy()
         data['text'] = json.dumps([
             {'family': 'DejaVu Sans', 'style': 'Book', 'text': 'Bad size', 'size': str(size), 'align': 'center'}
@@ -746,7 +746,7 @@ class TestLabelDesignerAPI:
         assert response.status_code == 400
 
     @pytest.mark.parametrize('size', [0, -1, -100])
-    def test_negative_zero_label_size(self, client, size):
+    def test_negative_zero_label_size(self, client: FlaskClient, size):
         data = EXAMPLE_FORMDATA.copy()
         data['label_size'] = size
         data['text'] = json.dumps([
@@ -755,7 +755,7 @@ class TestLabelDesignerAPI:
         response = client.post('/labeldesigner/api/preview', data=data)
         assert response.status_code == 400
 
-    def test_invalid_alignment(self, client):
+    def test_invalid_alignment(self, client: FlaskClient):
         data = EXAMPLE_FORMDATA.copy()
         data['text'] = json.dumps([
             {'family': 'DejaVu Sans', 'style': 'Book', 'text': 'Bad align', 'size': '12', 'align': 'diagonal'}
@@ -763,7 +763,7 @@ class TestLabelDesignerAPI:
         response = client.post('/labeldesigner/api/preview', data=data)
         assert response.status_code == 400
 
-    def test_non_string_text_value(self, client):
+    def test_non_string_text_value(self, client: FlaskClient):
         data = EXAMPLE_FORMDATA.copy()
         data['text'] = json.dumps([
             {'family': 'DejaVu Sans', 'style': 'Book', 'text': 12345, 'size': '12', 'align': 'center'}
@@ -771,7 +771,7 @@ class TestLabelDesignerAPI:
         response = client.post('/labeldesigner/api/preview', data=data)
         assert response.status_code == 400
 
-    def test_conflicting_fields(self, client):
+    def test_conflicting_fields(self, client: FlaskClient):
         data = EXAMPLE_FORMDATA.copy()
         data['print_type'] = 'qrcode_text'
         data['barcode_type'] = 'QR'
@@ -783,7 +783,7 @@ class TestLabelDesignerAPI:
         response = client.post('/labeldesigner/api/preview', data=data)
         assert response.status_code == 400
 
-    def test_unicode_normalization(self, client):
+    def test_unicode_normalization(self, client: FlaskClient):
         data = EXAMPLE_FORMDATA.copy()
         s1 = 'Café'
         s2 = unicodedata.normalize('NFD', s1)
@@ -798,17 +798,17 @@ class TestLabelDesignerAPI:
         # Check image
         self.verify_image(response.data, 'unicode_normalization.png')
 
-    def test_head_request(self, client):
+    def test_head_request(self, client: FlaskClient):
         response = client.head('/labeldesigner/api/preview')
         assert response.status_code == 405
 
-    def test_malformed_multipart(self, client):
+    def test_malformed_multipart(self, client: FlaskClient):
         # Simulate a malformed multipart by sending a bad content-type
         data = '--bad-boundary\r\nContent-Disposition: form-data; name="text"\r\n\r\nfoo\r\n--bad-boundary--\r\n'
         response = client.post('/labeldesigner/api/preview', data=data, headers={'Content-Type': 'multipart/form-data; boundary=bad-boundary'})
         assert response.status_code == 400
 
-    def test_unknown_font(self, client):
+    def test_unknown_font(self, client: FlaskClient):
         data = EXAMPLE_FORMDATA.copy()
         data['text'] = json.dumps([
             {'family': 'Droid Sand', 'style': 'Book', 'text': 'Item 1 (very small)', 'size': '15', 'align': 'left'}
@@ -828,7 +828,7 @@ class TestLabelDesignerAPI:
         data = response.get_json()
         assert data['message'] == 'Unknown font style: Non-exist for font Droid Sans'
 
-    def test_todo_list(self, client):
+    def test_todo_list(self, client: FlaskClient):
         data = EXAMPLE_FORMDATA.copy()
         data['text'] = json.dumps([
             {'family': 'Droid Sans', 'style': 'Regular', 'text': 'Item 1 (very small)', 'size': '15', 'align': 'left', 'todo': True},
@@ -843,22 +843,12 @@ class TestLabelDesignerAPI:
         # Check image
         self.verify_image(response.data, 'todo_list.png')
 
-
     # We cannot test the print functionality without a physical printer
-    # def test_print_label(self, client):
-    #    data = {
-    #        'print_type': 'text',
-    #        'label_size': '62',
-    #        'orientation': 'standard',
-    #        'text[0][family]': 'DejaVu Sans',
-    #        'text[0][style]': 'Book',
-    #        'text[0][text]': 'Test',
-    #        'text[0][size]': '12',
-    #        'text[0][align]': 'center',
-    #        'print_count': '1',
-    #        'cut_once': '0',
-    #    }
-    #    response = client.post('/labeldesigner/api/print', data=data)
-    #    assert response.status_code == 200
-    #    assert response.is_json
-    #    assert 'success' in response.get_json()
+    def test_print_label(self, client: FlaskClient):
+        data = EXAMPLE_FORMDATA.copy()
+        # Set config for printer
+        client.application.config['PRINTER_OFFLINE'] = True
+        response = client.post('/labeldesigner/api/print', data=data)
+        assert response.status_code == 200
+        assert response.is_json
+        assert 'success' in response.get_json()


### PR DESCRIPTION
Allow setting arguments via ENV vars, add new `PRINTER_OFFLINE` mode for offline mode simulation (no errors when trying to print) and prevent the frontend to make preview requests when styles are not yet loaded