### PR TITLE
Add webhook print endpoint and save simulated labels as PNG

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,6 @@ venv.bak/
 
 # idea
 .idea/*
+
+# Simulated label output
+simulated_labels/

--- a/app/labeldesigner/printer.py
+++ b/app/labeldesigner/printer.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import time
+import datetime
 from brother_ql.backends.helpers import send
 from brother_ql import BrotherQLRaster, create_label
 from brother_ql.backends.helpers import get_status
@@ -8,6 +9,8 @@ from brother_ql.backends import backend_factory, guess_backend
 from flask import Config
 from .label import LabelOrientation, LabelType, LabelContent
 from brother_ql.models import ALL_MODELS
+
+SIMULATED_LABELS_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))), 'simulated_labels')
 
 logger = logging.getLogger(__name__)
 
@@ -37,6 +40,8 @@ class PrinterQueue:
             logger.warning("Print queue is empty.")
             return "Print queue is empty."
         qlr = BrotherQLRaster(self.model)
+        is_simulation = isinstance(self.device_specifier, str) and self.device_specifier in ['simulation', '?']
+        generated_images = []
         for entry in self._print_queue:
             label = entry['label']
             cut = entry['cut']
@@ -46,6 +51,8 @@ class PrinterQueue:
             else:
                 rotate = 'auto'
             img = label.generate(rotate=False)
+            if is_simulation:
+                generated_images.append(img)
             dither = label.label_content != LabelContent.IMAGE_BW
             create_label(
                 qlr,
@@ -59,9 +66,15 @@ class PrinterQueue:
             )
         self._print_queue.clear()
         try:
-            # Simulator: pretend we sent data and return success
-            if isinstance(self.device_specifier, str) and (self.device_specifier in ['simulation', '?']):
+            # Simulator: pretend we sent data, save labels as PNG, and return success
+            if is_simulation:
                 logger.info('Simulated sending %d bytes to simulator printer', len(qlr.data))
+                os.makedirs(SIMULATED_LABELS_DIR, exist_ok=True)
+                ts = datetime.datetime.now().strftime('%Y%m%d_%H%M%S')
+                for i, img in enumerate(generated_images):
+                    path = os.path.join(SIMULATED_LABELS_DIR, f'{ts}_{i}.png')
+                    img.save(path, format='PNG')
+                    logger.info('Saved simulated label to %s', path)
                 return ""
 
             network_printer = isinstance(self.device_specifier, str) and self.device_specifier.startswith('tcp://')

--- a/app/labeldesigner/printer.py
+++ b/app/labeldesigner/printer.py
@@ -70,7 +70,7 @@ class PrinterQueue:
             if is_simulation:
                 logger.info('Simulated sending %d bytes to simulator printer', len(qlr.data))
                 os.makedirs(SIMULATED_LABELS_DIR, exist_ok=True)
-                ts = datetime.datetime.now().strftime('%Y%m%d_%H%M%S')
+                ts = datetime.datetime.utcnow().strftime('%Y%m%d_%H%M%S_%f')
                 for i, img in enumerate(generated_images):
                     path = os.path.join(SIMULATED_LABELS_DIR, f'{ts}_{i}.png')
                     img.save(path, format='PNG')

--- a/app/labeldesigner/routes.py
+++ b/app/labeldesigner/routes.py
@@ -774,7 +774,7 @@ def webhook_print():
 
     except Exception as e:
         current_app.logger.exception(e)
-        return make_response(jsonify({'success': False, 'message': str(e)}), 400)
+        return make_response(jsonify({'success': False, 'message': 'Invalid request parameters'}), 400)
 
     # Collect images from request
     pil_images = []
@@ -809,7 +809,7 @@ def webhook_print():
 
     except Exception as e:
         current_app.logger.exception(e)
-        return make_response(jsonify({'success': False, 'message': f'Failed to read images: {e}'}), 400)
+        return make_response(jsonify({'success': False, 'message': 'Failed to read images'}), 400)
 
     if not pil_images:
         return make_response(jsonify({'success': False, 'message': 'No images provided'}), 400)
@@ -834,7 +834,7 @@ def webhook_print():
         status = printer.process_queue()
     except Exception as e:
         current_app.logger.exception(e)
-        return make_response(jsonify({'success': False, 'message': str(e)}), 400)
+        return make_response(jsonify({'success': False, 'message': 'Failed to print labels'}), 400)
 
     result = {
         'success': len(status) == 0,

--- a/app/labeldesigner/routes.py
+++ b/app/labeldesigner/routes.py
@@ -1,4 +1,5 @@
 import os
+import hmac
 import base64
 import logging
 import barcode
@@ -478,14 +479,6 @@ def create_label_from_request(d: dict = {}, files: dict = {}, counter: int = 0):
         'code_text': d.get('code_text', '').strip(),
     }
 
-    def get_label_dimensions(label_size: str, high_res: bool = False):
-        dimensions = next((label.dots_printable for label in ALL_LABELS if label.identifier == label_size), None)
-        if dimensions is None:
-            raise LookupError("Unknown label_size")
-        if high_res:
-            return [2 * dimensions[0], 2 * dimensions[1]]
-        return dimensions
-
     def get_uploaded_image(image: FileStorage) -> Image.Image:
         name, ext = os.path.splitext(image.filename)
         ext = ext.lower()
@@ -540,7 +533,7 @@ def create_label_from_request(d: dict = {}, files: dict = {}, counter: int = 0):
     else:
         label_type = LabelType.ROUND_DIE_CUT_LABEL
 
-    width, height = get_label_dimensions(context['label_size'], context['high_res'])
+    width, height = _get_label_dimensions(context['label_size'], context['high_res'])
     if height > width:
         width, height = height, width
     if label_orientation == LabelOrientation.ROTATED:
@@ -664,7 +657,7 @@ def _scale_image_to_label(img: Image.Image, label_size: str, orientation: str,
         # For die-cut labels, fit within both dimensions
         scale = min(width / img_width, height / img_height)
 
-    new_size = (int(img_width * scale), int(img_height * scale))
+    new_size = (max(1, int(img_width * scale)), max(1, int(img_height * scale)))
     return img.resize(new_size, Image.Resampling.LANCZOS)
 
 
@@ -672,6 +665,8 @@ def _scale_image_to_label(img: Image.Image, label_size: str, orientation: str,
 def webhook_print():
     """
     Webhook endpoint for external services to print images directly.
+
+    URL: POST /labeldesigner/api/webhook/print
 
     Accepts multiple images via multipart form-data or JSON with base64-encoded
     images. Each image is scaled to fit the target label dimensions and printed
@@ -722,16 +717,18 @@ def webhook_print():
     if not webhook_password:
         return make_response(jsonify({'success': False, 'message': 'Webhook is not enabled'}), 403)
 
+    # Parse JSON body once (only when content type indicates JSON, not for multipart)
+    jdata = request.get_json(silent=True) or {}
+
     # Authenticate: accept password via Authorization Bearer token, query param, or JSON field
     provided = (request.headers.get('Authorization', '').removeprefix('Bearer ').strip()
                 or request.values.get('password', '')
-                or (request.get_json(force=True, silent=True) or {}).get('password', ''))
-    if not provided or provided != webhook_password:
+                or jdata.get('password', ''))
+    if not provided or not hmac.compare_digest(provided, webhook_password):
         return make_response(jsonify({'success': False, 'message': 'Unauthorized'}), 401)
 
     try:
         # Merge parameters from query/form and JSON body (query/form takes precedence)
-        jdata = request.get_json(force=True, silent=True) or {}
         def _param(key, default):
             return request.values.get(key) or jdata.get(key) or default
 

--- a/app/labeldesigner/routes.py
+++ b/app/labeldesigner/routes.py
@@ -1,6 +1,8 @@
 import os
+import base64
 import logging
 import barcode
+from io import BytesIO
 from . import bp
 from app import FONTS
 from PIL import Image
@@ -25,14 +27,16 @@ def handle_value_error(e):
 
 @bp.route('/')
 def index():
+    debug = current_app.logger.isEnabledFor(logging.DEBUG)
     label_sizes = [
-        (label.identifier, label.name, label.form_factor == FormFactor.ROUND_DIE_CUT, label.tape_size)
+        (label.identifier, label.name, label.form_factor == FormFactor.ROUND_DIE_CUT, label.tape_size, label.dots_printable)
         for label in ALL_LABELS
     ]
     return render_template(
         'labeldesigner.html',
         fonts=FONTS.fontlist(),
         label_sizes=label_sizes,
+        debug=debug,
         default_label_size=current_app.config['LABEL_DEFAULT_SIZE'],
         default_font_size=current_app.config['LABEL_DEFAULT_FONT_SIZE'],
         default_orientation=current_app.config['LABEL_DEFAULT_ORIENTATION'],
@@ -615,3 +619,228 @@ def create_label_from_request(d: dict = {}, files: dict = {}, counter: int = 0):
         counter=counter,
         code_text=context['code_text']
     )
+
+
+def _get_label_dimensions(label_size: str, high_res: bool = False):
+    dimensions = next((label.dots_printable for label in ALL_LABELS if label.identifier == label_size), None)
+    if dimensions is None:
+        raise LookupError("Unknown label_size")
+    if high_res:
+        return (2 * dimensions[0], 2 * dimensions[1])
+    return dimensions
+
+
+def _convert_image(img: Image.Image, image_mode: str, bw_threshold: int = 70) -> Image.Image:
+    if image_mode == 'grayscale':
+        return convert_image_to_grayscale(img)
+    elif image_mode == 'red_and_black':
+        return convert_image_to_red_and_black(img)
+    elif image_mode == 'colored':
+        return img
+    else:
+        return convert_image_to_bw(img, bw_threshold)
+
+
+def _scale_image_to_label(img: Image.Image, label_size: str, orientation: str,
+                          high_res: bool = False) -> Image.Image:
+    width, height = _get_label_dimensions(label_size, high_res)
+    # Normalize: width = printable width, height = printable height
+    if height > width:
+        width, height = height, width
+    if orientation == 'rotated':
+        height, width = width, height
+
+    kind = next((label.form_factor for label in ALL_LABELS if label.identifier == label_size), None)
+    is_endless = kind == FormFactor.ENDLESS
+
+    img_width, img_height = img.size
+    if is_endless:
+        # For endless labels, scale to fill the fixed dimension and let length vary
+        if orientation == 'rotated':
+            scale = height / img_height
+        else:
+            scale = width / img_width
+    else:
+        # For die-cut labels, fit within both dimensions
+        scale = min(width / img_width, height / img_height)
+
+    new_size = (int(img_width * scale), int(img_height * scale))
+    return img.resize(new_size, Image.Resampling.LANCZOS)
+
+
+@bp.route('/api/webhook/print', methods=['POST'])
+def webhook_print():
+    """
+    Webhook endpoint for external services to print images directly.
+
+    Accepts multiple images via multipart form-data or JSON with base64-encoded
+    images. Each image is scaled to fit the target label dimensions and printed
+    in batch with a cut after each label.
+
+    Authentication:
+        The webhook is disabled unless the WEBHOOK_PASSWORD environment variable
+        (or config key) is set. Generate a secure password with:
+
+            python3 -c "import secrets; print(secrets.token_urlsafe(32))"
+
+        Then export it before starting the server:
+
+            export WEBHOOK_PASSWORD="<generated-password>"
+
+        Authenticate requests using one of:
+        - Authorization header: ``Authorization: Bearer <password>``
+        - Form/query parameter: ``password=<password>``
+        - JSON body field: ``"password": "<password>"``
+
+    Multipart form-data:
+        - images: one or more image files (field name "images")
+        - label_size: label size identifier (default: from config)
+        - orientation: "standard" or "rotated" (default: from config)
+        - image_mode: "grayscale", "bw", "red_and_black", "colored" (default: from config)
+        - bw_threshold: black/white threshold 0-255 (default: from config)
+        - high_res: 0 or 1 for 600 DPI (default: 0)
+        - printer: printer device specifier (default: from config)
+        - model: printer model (default: from config)
+
+    JSON payload:
+        {
+            "images": [
+                {"data": "<base64>", "mime": "image/png"},
+                ...
+            ],
+            "label_size": "62",
+            "orientation": "standard",
+            "image_mode": "grayscale",
+            "bw_threshold": 70,
+            "high_res": 0,
+            "printer": "...",
+            "model": "..."
+        }
+    """
+    # Webhook is disabled unless WEBHOOK_PASSWORD is configured
+    webhook_password = current_app.config.get('WEBHOOK_PASSWORD', '')
+    if not webhook_password:
+        return make_response(jsonify({'success': False, 'message': 'Webhook is not enabled'}), 403)
+
+    # Authenticate: accept password via Authorization Bearer token, query param, or JSON field
+    provided = (request.headers.get('Authorization', '').removeprefix('Bearer ').strip()
+                or request.values.get('password', '')
+                or (request.get_json(force=True, silent=True) or {}).get('password', ''))
+    if not provided or provided != webhook_password:
+        return make_response(jsonify({'success': False, 'message': 'Unauthorized'}), 401)
+
+    try:
+        # Merge parameters from query/form and JSON body (query/form takes precedence)
+        jdata = request.get_json(force=True, silent=True) or {}
+        def _param(key, default):
+            return request.values.get(key) or jdata.get(key) or default
+
+        label_size = _param('label_size', current_app.config['LABEL_DEFAULT_SIZE'])
+        orientation = _param('orientation', current_app.config['LABEL_DEFAULT_ORIENTATION'])
+        image_mode = _param('image_mode', current_app.config['IMAGE_DEFAULT_MODE'])
+        bw_threshold = int(_param('bw_threshold', current_app.config['IMAGE_DEFAULT_BW_THRESHOLD']))
+        high_res = int(_param('high_res', 0)) != 0
+        device = _param('printer', current_app.config['PRINTER_PRINTER'])
+        model = _param('model', current_app.config['PRINTER_MODEL'])
+
+        # Validate label_size
+        kind = next((label.form_factor for label in ALL_LABELS if label.identifier == label_size), None)
+        if kind is None:
+            return make_response(jsonify({'success': False, 'message': f'Unknown label_size: {label_size}'}), 400)
+
+        # Determine label content type from image_mode
+        if image_mode == 'grayscale':
+            label_content = LabelContent.IMAGE_GRAYSCALE
+        elif image_mode == 'red_and_black':
+            label_content = LabelContent.IMAGE_RED_BLACK
+        elif image_mode == 'colored':
+            label_content = LabelContent.IMAGE_COLORED
+        else:
+            label_content = LabelContent.IMAGE_BW
+
+        label_orientation = LabelOrientation.ROTATED if orientation == 'rotated' else LabelOrientation.STANDARD
+        if kind == FormFactor.ENDLESS:
+            label_type = LabelType.ENDLESS_LABEL
+        elif kind == FormFactor.DIE_CUT:
+            label_type = LabelType.DIE_CUT_LABEL
+        else:
+            label_type = LabelType.ROUND_DIE_CUT_LABEL
+
+        width, height = _get_label_dimensions(label_size, high_res)
+        if height > width:
+            width, height = height, width
+        if label_orientation == LabelOrientation.ROTATED:
+            height, width = width, height
+
+    except Exception as e:
+        current_app.logger.exception(e)
+        return make_response(jsonify({'success': False, 'message': str(e)}), 400)
+
+    # Collect images from request
+    pil_images = []
+    try:
+        # Check for multipart file uploads first
+        uploaded_files = request.files.getlist('images')
+        if uploaded_files:
+            for f in uploaded_files:
+                if not f.filename:
+                    continue
+                _, ext = os.path.splitext(f.filename)
+                ext = ext.lower()
+                if ext == '.pdf':
+                    img = pdffile_to_image(f, HIGH_RES_DPI if high_res else DEFAULT_DPI)
+                else:
+                    img = imgfile_to_image(f)
+                pil_images.append(img)
+
+        # Check for JSON payload with base64 images
+        if not pil_images:
+            if jdata and isinstance(jdata.get('images'), list):
+                for entry in jdata['images']:
+                    if isinstance(entry, str):
+                        # Plain base64 string
+                        img_bytes = base64.b64decode(entry)
+                    elif isinstance(entry, dict) and 'data' in entry:
+                        img_bytes = base64.b64decode(entry['data'])
+                    else:
+                        continue
+                    img = Image.open(BytesIO(img_bytes))
+                    pil_images.append(img)
+
+    except Exception as e:
+        current_app.logger.exception(e)
+        return make_response(jsonify({'success': False, 'message': f'Failed to read images: {e}'}), 400)
+
+    if not pil_images:
+        return make_response(jsonify({'success': False, 'message': 'No images provided'}), 400)
+
+    # Process and queue each image
+    try:
+        printer = PrinterQueue(model=model, device_specifier=device, label_size=label_size)
+        for img in pil_images:
+            img = _convert_image(img, image_mode, bw_threshold)
+            img = _scale_image_to_label(img, label_size, orientation, high_res)
+            label = SimpleLabel(
+                width=width,
+                height=height,
+                label_content=label_content,
+                label_orientation=label_orientation,
+                label_type=label_type,
+                image=img,
+                image_fit=True,
+                text=[],
+            )
+            printer.add_label_to_queue(label, cut=True, high_res=high_res)
+        status = printer.process_queue()
+    except Exception as e:
+        current_app.logger.exception(e)
+        return make_response(jsonify({'success': False, 'message': str(e)}), 400)
+
+    result = {
+        'success': len(status) == 0,
+        'count': len(pil_images)
+    }
+    if status:
+        result['message'] = status
+        return make_response(jsonify(result), 400)
+    return jsonify(result)

--- a/app/labeldesigner/templates/labeldesigner.html
+++ b/app/labeldesigner/templates/labeldesigner.html
@@ -27,7 +27,7 @@
                             <select class="form-control form-select" id="label_size" onChange="preview()" data-default="{{default_label_size}}">
                                 {% for label_size in label_sizes %}<option value="{{label_size[0]}}" data-x="{{label_size[3][0]}}"
                                     data-y="{{label_size[3][1]}}" data-round="{{label_size[2]}}" {% if default_label_size==label_size[0]
-                                    %}selected{% endif %}>{{label_size[1]}}</option>{% endfor %}
+                                    %}selected{% endif %}>{{label_size[1]}}{% if debug %} ({{label_size[4][0]}}x{{label_size[4][1]}}px){% endif %}</option>{% endfor %}
                             </select>
                             <div class="form-text text-muted">Detected label: <span id="label-width">???</span> x <span id="label-height">???</span></div>
                             <div id="labelMismatch" class="form-text text-danger" style="display: none;">Label size mismatch detected!</div>

--- a/config.py
+++ b/config.py
@@ -37,3 +37,8 @@ class Config(object):
     LABEL_REPOSITORY_DIR = os.path.join(basedir, 'labels')
 
     FONT_FOLDER = ''
+
+    # Webhook print endpoint password. The webhook is disabled when empty.
+    # Generate a secure password with:
+    #   python3 -c "import secrets; print(secrets.token_urlsafe(32))"
+    WEBHOOK_PASSWORD = os.environ.get('WEBHOOK_PASSWORD', '')


### PR DESCRIPTION
Add password-protected webhook endpoint (POST /api/webhook/print) that accepts images from external services via multipart or JSON/base64, scales them to the target label dimensions, and prints them in batch. The webhook is disabled unless WEBHOOK_PASSWORD is set.

Additionally, simulated prints now save label images as PNG files to simulated_labels/ for debugging, and the label size dropdown shows pixel dimensions when log level is DEBUG.